### PR TITLE
Remove country check for onlince speech; idea folder added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ captures/
 # Intellij
 *.iml
 .idea/workspace.xml
+.idea/
 
 # Keystore files
 *.jks

--- a/app/src/main/java/ru/ibakaidov/distypepro/TTS.java
+++ b/app/src/main/java/ru/ibakaidov/distypepro/TTS.java
@@ -39,7 +39,7 @@ public class TTS  {
     }
     public void speak(String text){
 
-        if (this.isOnline&&this.isConnected && (Locale.getDefault().getCountry()=="RU")){
+        if (this.isOnline&&this.isConnected){
 
             Vocalizer vocalizer = Vocalizer.createVocalizer(Vocalizer.Language.RUSSIAN, text, true, voice.toLowerCase());
 


### PR DESCRIPTION
#4 
Проверка на локаль не нужна в данном месте :
1) Язык и страна на девайсе могут быть выставлены одни, а печатаемый текст может быть другим
2) Яндексовский SpeechKit и так отлично справляется как минимум одновременно с английским и с русским языком не смотря на то, что выставлен Vocalizer.Language.RUSSIAN